### PR TITLE
Adjust frontend login handling

### DIFF
--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -16,10 +16,15 @@ export const useUserStore = defineStore('user', () => {
     loading.value = true
     try {
       const response = await login(loginForm)
-      const { token: authToken, user: userInfo } = response.data
-      
+      const {
+        token: authToken,
+        userId,
+        tokenType,
+        ...userInfo
+      } = response.data
+
       token.value = authToken
-      user.value = userInfo
+      user.value = { id: userId, tokenType, ...userInfo }
       setToken(authToken)
       
       ElMessage.success('登录成功')


### PR DESCRIPTION
## Summary
- parse backend login response fields
- store userId as id when saving user

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cbac9d72c832c90254192f72ceef1