### PR TITLE
Add default admin initialization

### DIFF
--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -16,10 +16,15 @@ export const useUserStore = defineStore('user', () => {
     loading.value = true
     try {
       const response = await login(loginForm)
-      const { token: authToken, user: userInfo } = response.data
-      
+      const {
+        token: authToken,
+        userId,
+        tokenType,
+        ...userInfo
+      } = response.data
+
       token.value = authToken
-      user.value = userInfo
+      user.value = { id: userId, tokenType, ...userInfo }
       setToken(authToken)
       
       ElMessage.success('登录成功')

--- a/src/main/java/com/proshine/visitmanagement/config/DataInitializer.java
+++ b/src/main/java/com/proshine/visitmanagement/config/DataInitializer.java
@@ -1,0 +1,39 @@
+package com.proshine.visitmanagement.config;
+
+import com.proshine.visitmanagement.entity.User;
+import com.proshine.visitmanagement.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Initializes default data on application startup.
+ */
+@Component
+@Order(1)
+@RequiredArgsConstructor
+@Slf4j
+public class DataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        // Create default admin user when no users exist
+        if (userRepository.count() == 0 && !userRepository.existsByUsername("admin")) {
+            User admin = new User();
+            admin.setUsername("admin");
+            admin.setPassword(passwordEncoder.encode("123456"));
+            admin.setRealName("超级管理员");
+            admin.setRole(User.UserRole.ADMIN);
+            admin.setDepartment("系统");
+            admin.setStatus(User.UserStatus.ACTIVE);
+            userRepository.save(admin);
+            log.info("Initialized default admin user");
+        }
+    }
+}

--- a/src/main/java/com/proshine/visitmanagement/security/SecurityConfig.java
+++ b/src/main/java/com/proshine/visitmanagement/security/SecurityConfig.java
@@ -186,8 +186,10 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:3000",
                 "http://localhost:8080",
+                "http://localhost:8284",
                 "http://127.0.0.1:3000",
                 "http://127.0.0.1:8080",
+                "http://127.0.0.1:8284",
                 "https://*.yourdomain.com"
         ));
 


### PR DESCRIPTION
## Summary
- seed default admin user when database is empty

## Testing
- `npm run build` *(fails: vite not found)*
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cbac9d72c832c90254192f72ceef1