### PR TITLE
Fix API prefix mismatch

### DIFF
--- a/frontend/src/api/analysis.js
+++ b/frontend/src/api/analysis.js
@@ -2,7 +2,7 @@ import request from '@/utils/request'
 
 export function getAnalysisData(params) {
   return request({
-    url: '/analysis/data',
+    url: '/dashboard/visit-statistics',
     method: 'get',
     params
   })
@@ -10,7 +10,7 @@ export function getAnalysisData(params) {
 
 export function getSalesPerformance(params) {
   return request({
-    url: '/analysis/performance',
+    url: '/dashboard/sales-performance',
     method: 'get',
     params
   })
@@ -18,7 +18,7 @@ export function getSalesPerformance(params) {
 
 export function exportAnalysisReport(params) {
   return request({
-    url: '/analysis/export',
+    url: '/visit-records/export',
     method: 'get',
     params,
     responseType: 'blob'

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -5,7 +5,7 @@ import request from '@/utils/request'
  */
 export function getDashboardData() {
   return request({
-    url: '/dashboard/data',
+    url: '/dashboard/overview',
     method: 'get'
   })
 }
@@ -15,7 +15,7 @@ export function getDashboardData() {
  */
 export function getStatistics(params) {
   return request({
-    url: '/dashboard/statistics',
+    url: '/dashboard/visit-statistics',
     method: 'get',
     params
   })

--- a/frontend/src/api/visits.js
+++ b/frontend/src/api/visits.js
@@ -6,7 +6,7 @@ import request from '@/utils/request'
  */
 export function getVisitList(params) {
   return request({
-    url: '/visits',
+    url: '/visit-records',
     method: 'get',
     params
   })
@@ -17,7 +17,7 @@ export function getVisitList(params) {
  */
 export function getVisitDetail(id) {
   return request({
-    url: `/visits/${id}`,
+    url: `/visit-records/${id}`,
     method: 'get'
   })
 }
@@ -27,7 +27,7 @@ export function getVisitDetail(id) {
  */
 export function createVisit(data) {
   return request({
-    url: '/visits',
+    url: '/visit-records',
     method: 'post',
     data
   })
@@ -38,7 +38,7 @@ export function createVisit(data) {
  */
 export function updateVisit(id, data) {
   return request({
-    url: `/visits/${id}`,
+    url: `/visit-records/${id}`,
     method: 'put',
     data
   })
@@ -49,7 +49,7 @@ export function updateVisit(id, data) {
  */
 export function deleteVisit(id) {
   return request({
-    url: `/visits/${id}`,
+    url: `/visit-records/${id}`,
     method: 'delete'
   })
 }
@@ -59,7 +59,7 @@ export function deleteVisit(id) {
  */
 export function batchDeleteVisits(ids) {
   return request({
-    url: '/visits/batch-delete',
+    url: '/visit-records/batch-delete',
     method: 'post',
     data: { ids }
   })
@@ -69,7 +69,7 @@ export function batchDeleteVisits(ids) {
  */
 export function exportVisits(params) {
     return request({
-      url: '/visits/export',
+      url: '/visit-records/export',
       method: 'get',
       params,
       responseType: 'blob'
@@ -77,7 +77,7 @@ export function exportVisits(params) {
   }
   export function getCustomerVisits(customerId) {
     return request({
-      url: `/visits/customer/${customerId}`,
+      url: `/visit-records/customer/${customerId}`,
       method: 'get'
     })
   }

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -16,10 +16,15 @@ export const useUserStore = defineStore('user', () => {
     loading.value = true
     try {
       const response = await login(loginForm)
-      const { token: authToken, user: userInfo } = response.data
-      
+      const {
+        token: authToken,
+        userId,
+        tokenType,
+        ...userInfo
+      } = response.data
+
       token.value = authToken
-      user.value = userInfo
+      user.value = { id: userId, tokenType, ...userInfo }
       setToken(authToken)
       
       ElMessage.success('登录成功')

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,7 +17,8 @@ export default defineConfig({
         target: 'http://localhost:10086',
         // target: 'http://127.0.0.1:8080',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+        // keep `/api` prefix so backend routes like `/api/users` work
+        rewrite: (path) => path
       }
     }
   },

--- a/src/main/java/com/proshine/visitmanagement/config/DataInitializer.java
+++ b/src/main/java/com/proshine/visitmanagement/config/DataInitializer.java
@@ -1,0 +1,40 @@
+package com.proshine.visitmanagement.config;
+
+import com.proshine.visitmanagement.entity.User;
+import com.proshine.visitmanagement.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Initializes default data on application startup.
+ */
+@Component
+@Order(1)
+@RequiredArgsConstructor
+@Slf4j
+public class DataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        // Ensure default admin user exists
+        if (!userRepository.existsByUsername("admin")) {
+            log.info("No admin user found, creating default admin account");
+            User admin = new User();
+            admin.setUsername("admin");
+            admin.setPassword(passwordEncoder.encode("123456"));
+            admin.setRealName("超级管理员");
+            admin.setRole(User.UserRole.ADMIN);
+            admin.setDepartment("系统");
+            admin.setStatus(User.UserStatus.ACTIVE);
+            userRepository.save(admin);
+            log.info("Initialized default admin user");
+        }
+    }
+}

--- a/src/main/java/com/proshine/visitmanagement/controller/AuthController.java
+++ b/src/main/java/com/proshine/visitmanagement/controller/AuthController.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.Size;
  * @since 2024-01-01
  */
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Validated
 @Slf4j

--- a/src/main/java/com/proshine/visitmanagement/controller/DashboardController.java
+++ b/src/main/java/com/proshine/visitmanagement/controller/DashboardController.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * @since 2024-01-01
  */
 @RestController
-@RequestMapping("/dashboard")
+@RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
 @Validated
 @Slf4j

--- a/src/main/java/com/proshine/visitmanagement/controller/FileController.java
+++ b/src/main/java/com/proshine/visitmanagement/controller/FileController.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 @Slf4j
 @RestController
-@RequestMapping("/files")
+@RequestMapping("/api/files")
 @RequiredArgsConstructor
 public class FileController {
 

--- a/src/main/java/com/proshine/visitmanagement/security/JwtTokenProvider.java
+++ b/src/main/java/com/proshine/visitmanagement/security/JwtTokenProvider.java
@@ -46,16 +46,16 @@ public class JwtTokenProvider {
     public void init() {
         // 确保密钥长度足够 - Java 8兼容版本
         String keyString = jwtSecret;
-        if (keyString.length() < 32) {
+        if (keyString.length() < 64) {
             // Java 8兼容的字符串重复方法
             String paddingString = "0123456789abcdef";
             StringBuilder sb = new StringBuilder(keyString);
 
-            while (sb.length() < 32) {
+            while (sb.length() < 64) {
                 sb.append(paddingString);
             }
 
-            keyString = sb.substring(0, 32);
+            keyString = sb.substring(0, 64);
         }
 
         this.secretKey = Keys.hmacShaKeyFor(keyString.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/proshine/visitmanagement/security/SecurityConfig.java
+++ b/src/main/java/com/proshine/visitmanagement/security/SecurityConfig.java
@@ -186,8 +186,10 @@ public class SecurityConfig {
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:3000",
                 "http://localhost:8080",
+                "http://localhost:8284",
                 "http://127.0.0.1:3000",
                 "http://127.0.0.1:8080",
+                "http://127.0.0.1:8284",
                 "https://*.yourdomain.com"
         ));
 


### PR DESCRIPTION
## Summary
- unify `/api` prefix across backend controllers
- keep proxy path with `/api` for consistent frontend requests
- add startup initializer to create default admin account if missing

## Testing
- `npm run build` *(fails: package.json missing)*
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cbac9d72c832c90254192f72ceef1