### PR TITLE
Fix department tree API

### DIFF
--- a/frontend/src/views/customers/form.vue
+++ b/frontend/src/views/customers/form.vue
@@ -162,6 +162,7 @@
   <script setup>
   import { ref, reactive, computed, onMounted } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
+  import { ElMessage } from 'element-plus'
   import { getCustomerDetail, createCustomer, updateCustomer } from '@/api/customers'
   import { getSchoolDepartmentTree } from '@/api/schools'
   
@@ -203,7 +204,7 @@
     value: 'id',
     label: 'name',
     children: 'departments',
-    emitPath: false,
+    emitPath: true,
     checkStrictly: true
   }
   

--- a/src/main/java/com/proshine/visitmanagement/controller/SchoolController.java
+++ b/src/main/java/com/proshine/visitmanagement/controller/SchoolController.java
@@ -4,6 +4,7 @@ import com.proshine.visitmanagement.dto.request.SchoolRequest;
 import com.proshine.visitmanagement.dto.response.ApiResponse;
 import com.proshine.visitmanagement.dto.response.PageResponse;
 import com.proshine.visitmanagement.dto.response.SchoolResponse;
+import com.proshine.visitmanagement.dto.response.SchoolDepartmentTreeResponse;
 import com.proshine.visitmanagement.service.SchoolService;
 import com.proshine.visitmanagement.util.ExcelUtils;
 import com.proshine.visitmanagement.util.ValidationUtils;
@@ -243,6 +244,18 @@ public class SchoolController {
         Map<String, List<String>> provincesCities = schoolService.getProvincesCities();
 
         return ApiResponse.success(provincesCities, "获取省份城市列表成功");
+    }
+
+    /**
+     * 获取学校-院系树结构
+     */
+    @GetMapping("/tree")
+    public ApiResponse<List<SchoolDepartmentTreeResponse>> getSchoolDepartmentTree(Authentication authentication) {
+        log.debug("获取学校-院系树结构");
+
+        List<SchoolDepartmentTreeResponse> tree = schoolService.getSchoolDepartmentTree(authentication);
+
+        return ApiResponse.success(tree, "获取学校院系树成功");
     }
 
     /**

--- a/src/main/java/com/proshine/visitmanagement/dto/response/SchoolDepartmentTreeResponse.java
+++ b/src/main/java/com/proshine/visitmanagement/dto/response/SchoolDepartmentTreeResponse.java
@@ -1,0 +1,30 @@
+package com.proshine.visitmanagement.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 学校-院系树节点响应
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchoolDepartmentTreeResponse {
+    private Long id;
+    private String name;
+    private List<DepartmentNode> departments;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DepartmentNode {
+        private Long id;
+        private String name;
+    }
+}


### PR DESCRIPTION
## Summary
- add school department tree data dto
- implement `/api/schools/tree` endpoint
- expose new tree API on controller
- build department tree in service
- import `ElMessage` in customer form to prevent undefined error
- fix department cascader value path

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e37c98e94832ca81755b80d3632d5