### PR TITLE
Fix search API parameters for customer select

### DIFF
--- a/frontend/src/api/customers.js
+++ b/frontend/src/api/customers.js
@@ -55,10 +55,13 @@ export function exportCustomers(params) {
   })
 }
 
-export function searchCustomers(params) {
+export function searchCustomers(params = {}) {
+  const { keyword, page = 1, size = 10 } = params
+  if (!keyword || !keyword.trim()) {
+    return Promise.resolve({ data: { content: [] } })
+  }
   return request({
     url: '/customers/search',
     method: 'get',
-    params
-  })
-}
+    params: { keyword: keyword.trim(), page, size }
+  })}

--- a/frontend/src/views/visits/form.vue
+++ b/frontend/src/views/visits/form.vue
@@ -282,14 +282,21 @@
     status: [{ required: true, message: '请选择拜访状态', trigger: 'change' }]
   }
   
+  let searchTimeout
   const searchCustomers = async (query) => {
-    if (!query) return
-    try {
-      const response = await searchCustomersApi({ keyword: query })
-      customerOptions.value = response.data.content || []
-    } catch (error) {
-      console.error('搜索客户失败:', error)
+    if (!query || !query.trim()) {
+      customerOptions.value = []
+      return
     }
+    clearTimeout(searchTimeout)
+    searchTimeout = setTimeout(async () => {
+      try {
+        const response = await searchCustomersApi({ keyword: query.trim() })
+        customerOptions.value = response.data.content || []
+      } catch (error) {
+        console.error('搜索客户失败:', error)
+      }
+    }, 300)
   }
   
   const loadData = async () => {


### PR DESCRIPTION
## Summary
- handle empty keywords and pagination in `searchCustomers`
- debounce customer search requests in the visit form

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4207a0b4832c854db24bf43231af