### PR TITLE
Improve customer search validation to avoid 400 error

### DIFF
--- a/frontend/src/api/customers.js
+++ b/frontend/src/api/customers.js
@@ -55,10 +55,14 @@ export function exportCustomers(params) {
   })
 }
 
-export function searchCustomers(params) {
+export function searchCustomers(params = {}) {
+  const { keyword, page = 1, size = 10 } = params
+  const trimmed = typeof keyword === 'string' ? keyword.trim() : ''
+  if (!trimmed || trimmed.length < 2 || /^\d+$/.test(trimmed)) {
+    return Promise.resolve({ data: { content: [] } })
+  }
   return request({
     url: '/customers/search',
     method: 'get',
-    params
-  })
-}
+    params: { keyword: trimmed, page, size }
+  })}

--- a/frontend/src/views/visits/form.vue
+++ b/frontend/src/views/visits/form.vue
@@ -282,14 +282,26 @@
     status: [{ required: true, message: '请选择拜访状态', trigger: 'change' }]
   }
   
+  let searchTimeout
   const searchCustomers = async (query) => {
-    if (!query) return
-    try {
-      const response = await searchCustomersApi({ keyword: query })
-      customerOptions.value = response.data.content || []
-    } catch (error) {
-      console.error('搜索客户失败:', error)
+    const keyword = typeof query === 'string' ? query.trim() : ''
+    if (!keyword || keyword.length < 2 || /^\d+$/.test(keyword)) {
+      customerOptions.value = []
+      return
     }
+    clearTimeout(searchTimeout)
+    searchTimeout = setTimeout(async () => {
+      try {
+        const response = await searchCustomersApi({
+          keyword,
+          page: 1,
+          size: 20
+        })
+        customerOptions.value = response.data?.content || []
+      } catch (error) {
+        customerOptions.value = []
+      }
+    }, 300)
   }
   
   const loadData = async () => {


### PR DESCRIPTION
## Summary
- validate keyword in the customer search API
- add debounce and keyword checks in the visit form search

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4207a0b4832c854db24bf43231af