### PR TITLE
Fix visit update enum validation

### DIFF
--- a/src/main/java/com/proshine/visitmanagement/dto/request/VisitRecordRequest.java
+++ b/src/main/java/com/proshine/visitmanagement/dto/request/VisitRecordRequest.java
@@ -27,15 +27,15 @@ public class VisitRecordRequest {
     @Max(value = 1440, message = "拜访时长不能超过1440分钟")
     private Integer durationMinutes;
     
-    @Pattern(regexp = "FIRST_VISIT|FOLLOW_UP|TECHNICAL|BUSINESS|AFTER_SALES", 
+    @Pattern(regexp = "FIRST_VISIT|FOLLOW_UP|TECHNICAL|BUSINESS|AFTER_SALES|FACE_TO_FACE|PHONE_CALL|VIDEO_CALL|EMAIL|WECHAT|OTHER",
              message = "拜访类型无效")
     private String visitType = "FIRST_VISIT";
     
-    @Pattern(regexp = "SCHEDULED|COMPLETED|CANCELLED|POSTPONED", 
+    @Pattern(regexp = "SCHEDULED|COMPLETED|CANCELLED|POSTPONED|IN_PROGRESS|NO_SHOW",
              message = "拜访状态无效")
     private String status = "SCHEDULED";
     
-    @Pattern(regexp = "A|B|C|D", message = "意向等级无效")
+    @Pattern(regexp = "A|B|C|D|VERY_HIGH|HIGH|MEDIUM|LOW|VERY_LOW|NO_INTENT", message = "意向等级无效")
     private String intentLevel = "C";
     
     @Size(max = 1000, message = "可办事项长度不能超过1000个字符")

--- a/src/main/java/com/proshine/visitmanagement/service/VisitRecordService.java
+++ b/src/main/java/com/proshine/visitmanagement/service/VisitRecordService.java
@@ -605,15 +605,22 @@ public class VisitRecordService {
         }
         switch (type) {
             case "FIRST_VISIT":
+            case "FACE_TO_FACE":
                 return VisitRecord.VisitType.FACE_TO_FACE;
             case "FOLLOW_UP":
+            case "PHONE_CALL":
                 return VisitRecord.VisitType.PHONE_CALL;
             case "TECHNICAL":
+            case "VIDEO_CALL":
                 return VisitRecord.VisitType.VIDEO_CALL;
             case "BUSINESS":
+            case "EMAIL":
                 return VisitRecord.VisitType.EMAIL;
             case "AFTER_SALES":
+            case "WECHAT":
                 return VisitRecord.VisitType.WECHAT;
+            case "OTHER":
+                return VisitRecord.VisitType.OTHER;
             default:
                 return VisitRecord.VisitType.OTHER;
         }
@@ -628,13 +635,21 @@ public class VisitRecordService {
         }
         switch (level) {
             case "A":
+            case "VERY_HIGH":
                 return VisitRecord.IntentLevel.VERY_HIGH;
             case "B":
+            case "HIGH":
                 return VisitRecord.IntentLevel.HIGH;
             case "C":
+            case "MEDIUM":
                 return VisitRecord.IntentLevel.MEDIUM;
             case "D":
+            case "LOW":
                 return VisitRecord.IntentLevel.LOW;
+            case "VERY_LOW":
+                return VisitRecord.IntentLevel.VERY_LOW;
+            case "NO_INTENT":
+                return VisitRecord.IntentLevel.NO_INTENT;
             default:
                 return VisitRecord.IntentLevel.NO_INTENT;
         }


### PR DESCRIPTION
## Summary
- broaden VisitRecordRequest validation patterns to accept full enum names
- handle enum names in `VisitRecordService` conversion helpers

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f32d37660832c84bcfb7d548e92ca