### PR TITLE
Add responsive mobile layouts

### DIFF
--- a/frontend/src/views/analysis/index.vue
+++ b/frontend/src/views/analysis/index.vue
@@ -43,7 +43,7 @@
   
       <!-- 统计卡片 -->
       <el-row :gutter="20" class="stats-row">
-        <el-col :span="6" v-for="item in statsCards" :key="item.title">
+        <el-col :xs="12" :sm="6" :md="6" :lg="6" v-for="item in statsCards" :key="item.title">
           <el-card class="stat-card">
             <div class="stat-content">
               <div class="stat-icon" :style="{ background: item.color }">
@@ -65,7 +65,7 @@
       <!-- 图表区域 -->
       <el-row :gutter="20" class="charts-row">
         <!-- 拜访趋势图 -->
-        <el-col :span="12">
+        <el-col :xs="24" :md="12">
           <el-card title="拜访趋势分析">
             <template #header>
               <div class="card-header">
@@ -82,7 +82,7 @@
         </el-col>
         
         <!-- 意向分布图 -->
-        <el-col :span="12">
+        <el-col :xs="24" :md="12">
           <el-card title="意向等级分布">
             <template #header>
               <span>意向等级分布</span>
@@ -94,7 +94,7 @@
   
       <el-row :gutter="20" class="charts-row">
         <!-- 销售业绩排名 -->
-        <el-col :span="12">
+        <el-col :xs="24" :md="12">
           <el-card title="销售业绩排名">
             <template #header>
               <span>销售业绩排名</span>
@@ -104,7 +104,7 @@
         </el-col>
         
         <!-- 学校拜访排名 -->
-        <el-col :span="12">
+        <el-col :xs="24" :md="12">
           <el-card title="学校拜访排名">
             <template #header>
               <span>学校拜访排名</span>
@@ -448,10 +448,28 @@
   .analysis {
     .filter-card {
       margin-bottom: 20px;
+
+      @media (max-width: 768px) {
+        .el-form {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .el-form-item {
+          margin-right: 0;
+          width: 100%;
+        }
+      }
     }
     
     .stats-row {
       margin-bottom: 20px;
+
+      @media (max-width: 768px) {
+        .el-col {
+          width: 50%;
+        }
+      }
       
       .stat-card {
         .stat-content {
@@ -505,6 +523,12 @@
     
     .charts-row {
       margin-bottom: 20px;
+
+      @media (max-width: 768px) {
+        .el-col {
+          width: 100%;
+        }
+      }
       
       .chart {
         width: 100%;
@@ -513,6 +537,7 @@
     }
     
     .report-card {
+      overflow-x: auto;
       .card-header {
         display: flex;
         justify-content: space-between;

--- a/frontend/src/views/customers/index.vue
+++ b/frontend/src/views/customers/index.vue
@@ -147,13 +147,14 @@
         </el-table>
         
         <!-- 分页 -->
-        <div class="pagination">
+        <div class="pagination" :class="{ 'mobile-pagination': isMobile }">
           <el-pagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.size"
             :total="pagination.total"
-            :page-sizes="[10, 20, 50, 100]"
+            :page-sizes="isMobile ? [10, 20] : [10, 20, 50, 100]"
             layout="total, sizes, prev, pager, next, jumper"
+            :small="isMobile"
             @size-change="loadData"
             @current-change="loadData"
           />
@@ -163,7 +164,7 @@
   </template>
   
   <script setup>
-  import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted, onUnmounted } from 'vue'
   import { useRouter } from 'vue-router'
   import {
     Search, Refresh, Plus, Delete, Upload, Download
@@ -175,9 +176,14 @@
     exportCustomers
   } from '@/api/customers'
   
-  const router = useRouter()
-  
-  const loading = ref(false)
+const router = useRouter()
+
+const isMobile = ref(false)
+const checkScreenSize = () => {
+  isMobile.value = window.innerWidth <= 768
+}
+
+const loading = ref(false)
   const tableData = ref([])
   const selectedRows = ref([])
   
@@ -350,9 +356,15 @@
     return textMap[power] || power
   }
   
-  onMounted(() => {
-    loadData()
-  })
+onMounted(() => {
+  checkScreenSize()
+  window.addEventListener('resize', checkScreenSize)
+  loadData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', checkScreenSize)
+})
   </script>
   
   <style lang="scss" scoped>
@@ -362,6 +374,18 @@
       padding: 20px;
       background: #f5f7fa;
       border-radius: 4px;
+
+      @media (max-width: 768px) {
+        padding: 10px;
+        .el-form {
+          display: flex;
+          flex-direction: column;
+        }
+        .el-form-item {
+          margin-right: 0;
+          width: 100%;
+        }
+      }
     }
     
     .action-bar {
@@ -369,6 +393,22 @@
       justify-content: space-between;
       align-items: center;
       margin-bottom: 20px;
+
+      @media (max-width: 768px) {
+        flex-direction: column;
+        gap: 10px;
+
+        .action-left {
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+
+          .el-button {
+            width: 100%;
+          }
+        }
+      }
     }
     
     .customer-name {
@@ -394,6 +434,14 @@
     .pagination {
       margin-top: 20px;
       text-align: right;
+
+      &.mobile-pagination {
+        text-align: center;
+
+        .el-pagination {
+          justify-content: center;
+        }
+      }
     }
   }
   </style>

--- a/frontend/src/views/system/schools.vue
+++ b/frontend/src/views/system/schools.vue
@@ -152,13 +152,14 @@
       </el-table>
 
       <!-- 分页 -->
-      <div class="pagination">
+      <div class="pagination" :class="{ 'mobile-pagination': isMobile }">
         <el-pagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.size"
             :total="pagination.total"
-            :page-sizes="[10, 20, 50, 100]"
+            :page-sizes="isMobile ? [10, 20] : [10, 20, 50, 100]"
             layout="total, sizes, prev, pager, next, jumper"
+            :small="isMobile"
             @size-change="loadData"
             @current-change="loadData"
         />
@@ -278,7 +279,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted, onUnmounted } from 'vue'
 import { Search, Refresh, Plus, Upload, Download } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import {
@@ -303,6 +304,11 @@ const departmentSubmitting = ref(false)
 
 const schoolFormRef = ref()
 const departmentFormRef = ref()
+
+const isMobile = ref(false)
+const checkScreenSize = () => {
+  isMobile.value = window.innerWidth <= 768
+}
 
 const searchForm = reactive({
   keyword: '',
@@ -628,7 +634,13 @@ const getSchoolTypeText = (type) => {
 }
 
 onMounted(() => {
+  checkScreenSize()
+  window.addEventListener('resize', checkScreenSize)
   loadData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', checkScreenSize)
 })
 </script>
 
@@ -639,6 +651,18 @@ onMounted(() => {
     padding: 20px;
     background: #f5f7fa;
     border-radius: 4px;
+
+    @media (max-width: 768px) {
+      padding: 10px;
+      .el-form {
+        display: flex;
+        flex-direction: column;
+      }
+      .el-form-item {
+        margin-right: 0;
+        width: 100%;
+      }
+    }
   }
 
   .action-bar {
@@ -646,6 +670,22 @@ onMounted(() => {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 20px;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+      gap: 10px;
+
+      .action-left {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        .el-button {
+          width: 100%;
+        }
+      }
+    }
   }
 
   .expand-content {
@@ -675,6 +715,14 @@ onMounted(() => {
   .pagination {
     margin-top: 20px;
     text-align: right;
+
+    &.mobile-pagination {
+      text-align: center;
+
+      .el-pagination {
+        justify-content: center;
+      }
+    }
   }
 }
 </style>

--- a/frontend/src/views/system/users.vue
+++ b/frontend/src/views/system/users.vue
@@ -161,13 +161,14 @@
         </el-table>
         
         <!-- 分页 -->
-        <div class="pagination">
+        <div class="pagination" :class="{ 'mobile-pagination': isMobile }">
           <el-pagination
             v-model:current-page="pagination.page"
             v-model:page-size="pagination.size"
             :total="pagination.total"
-            :page-sizes="[10, 20, 50, 100]"
+            :page-sizes="isMobile ? [10, 20] : [10, 20, 50, 100]"
             layout="total, sizes, prev, pager, next, jumper"
+            :small="isMobile"
             @size-change="loadData"
             @current-change="loadData"
           />
@@ -239,7 +240,7 @@
   </template>
   
   <script setup>
-  import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
   import { useUserStore } from '@/stores/user'
   import {
     Search, Refresh, Plus, Delete
@@ -263,12 +264,17 @@ import { ElMessage, ElMessageBox } from 'element-plus'
     { label: '销售', value: 'SALES' }
   ]
   
-  const loading = ref(false)
-  const dialogVisible = ref(false)
-  const submitting = ref(false)
-  const tableData = ref([])
-  const selectedRows = ref([])
-  const formRef = ref()
+const loading = ref(false)
+const dialogVisible = ref(false)
+const submitting = ref(false)
+const tableData = ref([])
+const selectedRows = ref([])
+const formRef = ref()
+
+const isMobile = ref(false)
+const checkScreenSize = () => {
+  isMobile.value = window.innerWidth <= 768
+}
   
   const currentUserId = computed(() => userStore.user?.id)
   const isEdit = ref(false)
@@ -505,9 +511,15 @@ import { ElMessage, ElMessageBox } from 'element-plus'
     return new Date(dateTime).toLocaleString('zh-CN')
   }
   
-  onMounted(() => {
-    loadData()
-  })
+onMounted(() => {
+  checkScreenSize()
+  window.addEventListener('resize', checkScreenSize)
+  loadData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', checkScreenSize)
+})
   </script>
   
   <style lang="scss" scoped>
@@ -517,6 +529,18 @@ import { ElMessage, ElMessageBox } from 'element-plus'
       padding: 20px;
       background: #f5f7fa;
       border-radius: 4px;
+
+      @media (max-width: 768px) {
+        padding: 10px;
+        .el-form {
+          display: flex;
+          flex-direction: column;
+        }
+        .el-form-item {
+          margin-right: 0;
+          width: 100%;
+        }
+      }
     }
     
     .action-bar {
@@ -524,6 +548,22 @@ import { ElMessage, ElMessageBox } from 'element-plus'
       justify-content: space-between;
       align-items: center;
       margin-bottom: 20px;
+
+      @media (max-width: 768px) {
+        flex-direction: column;
+        gap: 10px;
+
+        .action-left {
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+
+          .el-button {
+            width: 100%;
+          }
+        }
+      }
     }
     
     .user-info {
@@ -548,6 +588,14 @@ import { ElMessage, ElMessageBox } from 'element-plus'
     .pagination {
       margin-top: 20px;
       text-align: right;
+
+      &.mobile-pagination {
+        text-align: center;
+
+        .el-pagination {
+          justify-content: center;
+        }
+      }
     }
 
     .actions {


### PR DESCRIPTION
## Summary
- adapt analysis page charts and stats layout for small screens
- make customer list responsive with mobile-friendly pagination
- apply responsive search/action sections for school management
- update user management layout with mobile awareness

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6ee2df10832ca2b1a9edab3cf8a3