### PR TITLE
Add mobile layout and routes

### DIFF
--- a/frontend/src/layout/MobileLayout.vue
+++ b/frontend/src/layout/MobileLayout.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="mobile-layout">
+    <header class="mobile-header">
+      <el-button text class="back-btn" @click="goBack" v-if="showBack">
+        <el-icon><arrow-left /></el-icon>
+      </el-button>
+      <span class="title">{{ title }}</span>
+      <slot name="header-right"></slot>
+    </header>
+    <main class="mobile-main">
+      <slot />
+    </main>
+    <nav class="mobile-tab-bar">
+      <div class="tab-item" :class="{ active: isActive('/m/dashboard') }" @click="router.push('/m/dashboard')">
+        <el-icon><Odometer /></el-icon>
+        <span>首页</span>
+      </div>
+      <div class="tab-item" :class="{ active: isActive('/m/customers/list') }" @click="router.push('/m/customers/list')">
+        <el-icon><UserFilled /></el-icon>
+        <span>客户</span>
+      </div>
+      <div class="tab-item" :class="{ active: isActive('/m/visits/list') }" @click="router.push('/m/visits/list')">
+        <el-icon><Notebook /></el-icon>
+        <span>拜访</span>
+      </div>
+    </nav>
+  </div>
+</template>
+
+<script setup>
+import { useRouter, useRoute } from 'vue-router'
+import { ArrowLeft, Odometer, UserFilled, Notebook } from '@element-plus/icons-vue'
+
+const props = defineProps({
+  title: { type: String, default: '' },
+  showBack: { type: Boolean, default: true }
+})
+
+const router = useRouter()
+const route = useRoute()
+
+const goBack = () => {
+  router.back()
+}
+
+const isActive = (path) => {
+  return route.path.startsWith(path)
+}
+</script>
+
+<style scoped>
+.mobile-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.mobile-header {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  height: 50px;
+  background: #409EFF;
+  color: #fff;
+}
+
+.title {
+  flex: 1;
+  text-align: center;
+  font-weight: bold;
+}
+
+.mobile-main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.mobile-tab-bar {
+  display: flex;
+  border-top: 1px solid #e0e0e0;
+}
+
+.tab-item {
+  flex: 1;
+  text-align: center;
+  padding: 8px 0;
+  color: #666;
+}
+
+.tab-item.active {
+  color: #409EFF;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { useUserStore } from '@/stores/user'
 import Layout from '@/layout/index.vue'
 
+
 const routes = [
   {
     path: '/login',
@@ -167,8 +168,8 @@ const routes = [
   {
     path: '/system',
     component: Layout,
-    meta: { 
-      title: '系统管理', 
+    meta: {
+      title: '系统管理',
       icon: 'Setting', 
       requiresAuth: true, 
       roles: ['ADMIN', 'MANAGER'] 
@@ -194,6 +195,67 @@ const routes = [
         }
       }
     ]
+  },
+  // 移动端路由
+  {
+    path: '/m/login',
+    component: () => import('@/views/mobile/LoginMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/dashboard',
+    component: () => import('@/views/mobile/DashboardMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/visits/list',
+    component: () => import('@/views/mobile/VisitListMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/visits/create',
+    component: () => import('@/views/mobile/VisitFormMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/visits/edit/:id',
+    component: () => import('@/views/mobile/VisitFormMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/visits/detail/:id',
+    component: () => import('@/views/mobile/VisitDetailMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/customers/list',
+    component: () => import('@/views/mobile/CustomerListMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/customers/create',
+    component: () => import('@/views/mobile/CustomerFormMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/customers/edit/:id',
+    component: () => import('@/views/mobile/CustomerFormMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/customers/detail/:id',
+    component: () => import('@/views/mobile/CustomerDetailMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/system/users',
+    component: () => import('@/views/mobile/UserListMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/system/schools',
+    component: () => import('@/views/mobile/SchoolListMobile.vue'),
+    meta: { hidden: true }
   },
 //   {
 //     path: '/profile',

--- a/frontend/src/views/mobile/CustomerDetailMobile.vue
+++ b/frontend/src/views/mobile/CustomerDetailMobile.vue
@@ -1,0 +1,31 @@
+<template>
+  <MobileLayout title="客户详情">
+    <el-card v-if="data">
+      <el-descriptions :column="1" border>
+        <el-descriptions-item label="姓名">{{ data.name }}</el-descriptions-item>
+        <el-descriptions-item label="职位">{{ data.position }}</el-descriptions-item>
+        <el-descriptions-item label="学校">{{ data.schoolName }}</el-descriptions-item>
+        <el-descriptions-item label="院系">{{ data.departmentName }}</el-descriptions-item>
+        <el-descriptions-item label="电话">{{ data.phone }}</el-descriptions-item>
+      </el-descriptions>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getCustomerDetail } from '@/api/customers'
+
+const route = useRoute()
+const data = ref(null)
+
+onMounted(async () => {
+  const { data: res } = await getCustomerDetail(route.params.id)
+  data.value = res
+})
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/mobile/CustomerFormMobile.vue
+++ b/frontend/src/views/mobile/CustomerFormMobile.vue
@@ -1,0 +1,46 @@
+<template>
+  <MobileLayout title="客户表单">
+    <el-form ref="formRef" :model="form" label-width="80px">
+      <el-form-item label="姓名" prop="name">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item label="学校" prop="schoolName">
+        <el-input v-model="form.schoolName" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" style="width:100%" @click="submit">保存</el-button>
+      </el-form-item>
+    </el-form>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { createCustomer, updateCustomer, getCustomerDetail } from '@/api/customers'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+const formRef = ref()
+const form = reactive({ name: '', schoolName: '' })
+
+if (route.params.id) {
+  getCustomerDetail(route.params.id).then(({ data }) => Object.assign(form, data))
+}
+
+const submit = async () => {
+  if (!formRef.value) return
+  const valid = await formRef.value.validate().catch(() => false)
+  if (!valid) return
+  if (route.params.id) {
+    await updateCustomer(route.params.id, form)
+  } else {
+    await createCustomer(form)
+  }
+  router.back()
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/mobile/CustomerListMobile.vue
+++ b/frontend/src/views/mobile/CustomerListMobile.vue
@@ -1,0 +1,43 @@
+<template>
+  <MobileLayout title="客户列表">
+    <el-card v-for="item in list" :key="item.id" class="mb-2" @click="view(item)">
+      <div class="title-row">{{ item.name }}</div>
+      <div class="info">{{ item.schoolName }} {{ item.departmentName }}</div>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getCustomerList } from '@/api/customers'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const list = ref([])
+
+const load = async () => {
+  const { data } = await getCustomerList({ page: 0, size: 20 })
+  list.value = data.content || []
+}
+
+const view = (item) => {
+  router.push(`/m/customers/detail/${item.id}`)
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.mb-2 {
+  margin-bottom: 12px;
+}
+.title-row {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.info {
+  font-size: 12px;
+  color: #666;
+}
+</style>

--- a/frontend/src/views/mobile/DashboardMobile.vue
+++ b/frontend/src/views/mobile/DashboardMobile.vue
@@ -1,0 +1,14 @@
+<template>
+  <MobileLayout title="首页" :showBack="false">
+    <el-card>
+      <p>移动端仪表盘内容</p>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import MobileLayout from '@/layout/MobileLayout.vue'
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/mobile/LoginMobile.vue
+++ b/frontend/src/views/mobile/LoginMobile.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="login-mobile">
+    <el-card class="login-card">
+      <h2 class="title">客户拜访管理</h2>
+      <el-form ref="formRef" :model="form" :rules="rules" @keyup.enter="submit">
+        <el-form-item prop="username">
+          <el-input v-model="form.username" placeholder="用户名" />
+        </el-form-item>
+        <el-form-item prop="password">
+          <el-input v-model="form.password" type="password" placeholder="密码" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :loading="userStore.loading" style="width:100%" @click="submit">登录</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import { useUserStore } from '@/stores/user'
+
+const userStore = useUserStore()
+const formRef = ref()
+const form = reactive({ username: 'admin', password: '123456' })
+const rules = {
+  username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
+  password: [{ required: true, message: '请输入密码', trigger: 'blur' }]
+}
+const submit = async () => {
+  if (!formRef.value) return
+  await formRef.value.validate(async (valid) => {
+    if (valid) {
+      await userStore.userLogin(form)
+    }
+  })
+}
+</script>
+
+<style scoped>
+.login-mobile {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f7fa;
+  padding: 20px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 320px;
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 20px;
+}
+</style>

--- a/frontend/src/views/mobile/SchoolListMobile.vue
+++ b/frontend/src/views/mobile/SchoolListMobile.vue
@@ -1,0 +1,27 @@
+<template>
+  <MobileLayout title="学校管理">
+    <el-card v-for="s in list" :key="s.id" class="mb-2">
+      <div class="title-row">{{ s.name }}</div>
+      <div class="info">{{ s.city }}</div>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getSchoolList } from '@/api/schools'
+
+const list = ref([])
+
+onMounted(async () => {
+  const { data } = await getSchoolList({ page: 0, size: 20 })
+  list.value = data.content || []
+})
+</script>
+
+<style scoped>
+.mb-2 { margin-bottom: 12px; }
+.title-row { font-weight: bold; margin-bottom: 4px; }
+.info { font-size: 12px; color: #666; }
+</style>

--- a/frontend/src/views/mobile/UserListMobile.vue
+++ b/frontend/src/views/mobile/UserListMobile.vue
@@ -1,0 +1,27 @@
+<template>
+  <MobileLayout title="用户管理">
+    <el-card v-for="u in list" :key="u.id" class="mb-2">
+      <div class="title-row">{{ u.username }}</div>
+      <div class="info">{{ u.role }}</div>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getUserList } from '@/api/users'
+
+const list = ref([])
+
+onMounted(async () => {
+  const { data } = await getUserList({ page: 0, size: 20 })
+  list.value = data.content || []
+})
+</script>
+
+<style scoped>
+.mb-2 { margin-bottom: 12px; }
+.title-row { font-weight: bold; margin-bottom: 4px; }
+.info { font-size: 12px; color: #666; }
+</style>

--- a/frontend/src/views/mobile/VisitDetailMobile.vue
+++ b/frontend/src/views/mobile/VisitDetailMobile.vue
@@ -1,0 +1,38 @@
+<template>
+  <MobileLayout title="拜访详情">
+    <el-card v-if="data">
+      <el-descriptions :column="1" border>
+        <el-descriptions-item label="客户">{{ data.customerName }}</el-descriptions-item>
+        <el-descriptions-item label="日期">{{ data.visitDate }}</el-descriptions-item>
+        <el-descriptions-item label="类型">{{ data.visitType }}</el-descriptions-item>
+        <el-descriptions-item label="状态">{{ data.status }}</el-descriptions-item>
+      </el-descriptions>
+      <div class="content" v-if="data.content">
+        <h4>交流内容</h4>
+        <p>{{ data.content }}</p>
+      </div>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getVisitDetail } from '@/api/visits'
+
+const route = useRoute()
+const data = ref(null)
+
+onMounted(async () => {
+  const { data: res } = await getVisitDetail(route.params.id)
+  data.value = res
+})
+</script>
+
+<style scoped>
+.content {
+  margin-top: 12px;
+  line-height: 1.4;
+}
+</style>

--- a/frontend/src/views/mobile/VisitFormMobile.vue
+++ b/frontend/src/views/mobile/VisitFormMobile.vue
@@ -1,0 +1,52 @@
+<template>
+  <MobileLayout title="拜访表单">
+    <el-form ref="formRef" :model="form" label-width="80px">
+      <el-form-item label="客户" prop="customerId">
+        <el-input v-model="form.customerId" placeholder="客户ID" />
+      </el-form-item>
+      <el-form-item label="日期" prop="visitDate">
+        <el-date-picker v-model="form.visitDate" style="width:100%" />
+      </el-form-item>
+      <el-form-item label="类型" prop="visitType">
+        <el-select v-model="form.visitType" style="width:100%">
+          <el-option label="电话" value="PHONE" />
+          <el-option label="上门" value="VISIT" />
+        </el-select>
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" style="width:100%" @click="submit">保存</el-button>
+      </el-form-item>
+    </el-form>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { reactive, ref } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { createVisit, updateVisit, getVisitDetail } from '@/api/visits'
+import { useRoute, useRouter } from 'vue-router'
+
+const router = useRouter()
+const route = useRoute()
+const formRef = ref()
+const form = reactive({ customerId: '', visitDate: '', visitType: 'PHONE' })
+
+if (route.params.id) {
+  getVisitDetail(route.params.id).then(({ data }) => Object.assign(form, data))
+}
+
+const submit = async () => {
+  if (!formRef.value) return
+  const valid = await formRef.value.validate().catch(() => false)
+  if (!valid) return
+  if (route.params.id) {
+    await updateVisit(route.params.id, form)
+  } else {
+    await createVisit(form)
+  }
+  router.back()
+}
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/mobile/VisitListMobile.vue
+++ b/frontend/src/views/mobile/VisitListMobile.vue
@@ -1,0 +1,48 @@
+<template>
+  <MobileLayout title="拜访记录">
+    <el-card v-for="item in list" :key="item.id" class="mb-2" @click="view(item)">
+      <div class="title-row">
+        <span>{{ item.customerName }}</span>
+        <el-tag :type="item.status === 'COMPLETED' ? 'success' : 'info'" size="small">{{ item.status }}</el-tag>
+      </div>
+      <div class="info">{{ item.visitDate }} | {{ item.visitType }}</div>
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getVisitList } from '@/api/visits'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const list = ref([])
+
+const load = async () => {
+  const { data } = await getVisitList({ page: 0, size: 20 })
+  list.value = data.content || []
+}
+
+const view = (item) => {
+  router.push(`/m/visits/detail/${item.id}`)
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.mb-2 {
+  margin-bottom: 12px;
+}
+.title-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-weight: bold;
+}
+.info {
+  font-size: 12px;
+  color: #666;
+}
+</style>


### PR DESCRIPTION
## Summary
- introduce `MobileLayout` with basic tab bar
- add mobile route entries under `/m` prefix
- scaffold mobile-specific pages for login, dashboard, visits, customers and system management

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f77fcc0cc832c901270a68ba7a310