### PR TITLE
Add mobile pages and UI improvements

### DIFF
--- a/frontend/src/layout/MobileLayout.vue
+++ b/frontend/src/layout/MobileLayout.vue
@@ -11,7 +11,7 @@
       <slot />
     </main>
     <nav class="mobile-tab-bar">
-      <div class="tab-item" :class="{ active: isActive('/m/dashboard') }" @click="router.push('/m/dashboard')">
+      <div class="tab-item" :class="{ active: isActive('/m/home') }" @click="router.push('/m/home')">
         <el-icon><Odometer /></el-icon>
         <span>首页</span>
       </div>
@@ -86,9 +86,11 @@ const isActive = (path) => {
   text-align: center;
   padding: 8px 0;
   color: #666;
+  transition: color 0.3s, transform 0.3s;
 }
 
 .tab-item.active {
   color: #409EFF;
+  transform: scale(1.05);
 }
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -203,13 +203,22 @@ const routes = [
     meta: { hidden: true }
   },
   {
-    path: '/m/dashboard',
+    path: '/m/home',
     component: () => import('@/views/mobile/DashboardMobile.vue'),
     meta: { hidden: true }
   },
   {
+    path: '/m/dashboard',
+    redirect: '/m/home'
+  },
+  {
     path: '/m/visits/list',
     component: () => import('@/views/mobile/VisitListMobile.vue'),
+    meta: { hidden: true }
+  },
+  {
+    path: '/m/analysis',
+    component: () => import('@/views/mobile/DataAnalysisMobile.vue'),
     meta: { hidden: true }
   },
   {

--- a/frontend/src/views/mobile/CustomerFormMobile.vue
+++ b/frontend/src/views/mobile/CustomerFormMobile.vue
@@ -4,8 +4,22 @@
       <el-form-item label="姓名" prop="name">
         <el-input v-model="form.name" />
       </el-form-item>
-      <el-form-item label="学校" prop="schoolName">
-        <el-input v-model="form.schoolName" />
+      <el-form-item label="职位" prop="position">
+        <el-input v-model="form.position" />
+      </el-form-item>
+      <el-form-item label="电话" prop="phone">
+        <el-input v-model="form.phone" />
+      </el-form-item>
+      <el-form-item label="学校" prop="schoolId">
+        <el-select v-model="form.schoolId" style="width:100%">
+          <el-option v-for="s in schools" :key="s.id" :label="s.name" :value="s.id" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="院系" prop="departmentName">
+        <el-input v-model="form.departmentName" />
+      </el-form-item>
+      <el-form-item label="邮箱" prop="email">
+        <el-input v-model="form.email" />
       </el-form-item>
       <el-form-item>
         <el-button type="primary" style="width:100%" @click="submit">保存</el-button>
@@ -15,19 +29,35 @@
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue'
+import { reactive, ref, onMounted } from 'vue'
 import MobileLayout from '@/layout/MobileLayout.vue'
 import { createCustomer, updateCustomer, getCustomerDetail } from '@/api/customers'
+import { getSchoolList } from '@/api/schools'
 import { useRoute, useRouter } from 'vue-router'
 
 const route = useRoute()
 const router = useRouter()
 const formRef = ref()
-const form = reactive({ name: '', schoolName: '' })
+const form = reactive({
+  name: '',
+  position: '',
+  phone: '',
+  schoolId: null,
+  departmentName: '',
+  email: ''
+})
+const schools = ref([])
+
+const loadSchools = async () => {
+  const { data } = await getSchoolList({ page: 0, size: 100 })
+  schools.value = data.content || []
+}
 
 if (route.params.id) {
   getCustomerDetail(route.params.id).then(({ data }) => Object.assign(form, data))
 }
+
+onMounted(loadSchools)
 
 const submit = async () => {
   if (!formRef.value) return

--- a/frontend/src/views/mobile/CustomerListMobile.vue
+++ b/frontend/src/views/mobile/CustomerListMobile.vue
@@ -1,5 +1,8 @@
 <template>
   <MobileLayout title="客户列表">
+    <template #header-right>
+      <el-button text @click="add"><el-icon><Plus /></el-icon></el-button>
+    </template>
     <el-card v-for="item in list" :key="item.id" class="mb-2" @click="view(item)">
       <div class="title-row">{{ item.name }}</div>
       <div class="info">{{ item.schoolName }} {{ item.departmentName }}</div>
@@ -12,6 +15,7 @@ import { ref, onMounted } from 'vue'
 import MobileLayout from '@/layout/MobileLayout.vue'
 import { getCustomerList } from '@/api/customers'
 import { useRouter } from 'vue-router'
+import { Plus } from '@element-plus/icons-vue'
 
 const router = useRouter()
 const list = ref([])
@@ -23,6 +27,10 @@ const load = async () => {
 
 const view = (item) => {
   router.push(`/m/customers/detail/${item.id}`)
+}
+
+const add = () => {
+  router.push('/m/customers/create')
 }
 
 onMounted(load)

--- a/frontend/src/views/mobile/DataAnalysisMobile.vue
+++ b/frontend/src/views/mobile/DataAnalysisMobile.vue
@@ -1,0 +1,79 @@
+<template>
+  <MobileLayout title="数据分析" :showBack="false">
+    <el-card v-if="stats">
+      <div class="stats">
+        <div class="stat-item">
+          <div class="value">{{ stats.totalVisits }}</div>
+          <div class="label">总次数</div>
+        </div>
+        <div class="stat-item">
+          <div class="value">{{ stats.completionRate }}%</div>
+          <div class="label">完成率</div>
+        </div>
+        <div class="stat-item">
+          <div class="value">{{ stats.intentLevel }}</div>
+          <div class="label">意向等级</div>
+        </div>
+      </div>
+    </el-card>
+    <el-card style="margin-top:12px">
+      <v-chart class="chart" :option="trendOption" />
+    </el-card>
+  </MobileLayout>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import MobileLayout from '@/layout/MobileLayout.vue'
+import { getAnalysisData } from '@/api/analysis'
+import { use } from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { CanvasRenderer } from 'echarts/renderers'
+import { TitleComponent, TooltipComponent } from 'echarts/components'
+import VChart from 'vue-echarts'
+
+use([CanvasRenderer, LineChart, TitleComponent, TooltipComponent])
+
+const stats = ref(null)
+const trendOption = ref({
+  title: { text: '趋势图', left: 'center' },
+  tooltip: { trigger: 'axis' },
+  xAxis: { type: 'category', data: [] },
+  yAxis: { type: 'value' },
+  series: [{ type: 'line', data: [] }]
+})
+
+const loadData = async () => {
+  const { data } = await getAnalysisData({})
+  stats.value = {
+    totalVisits: data?.stats?.totalVisits || 0,
+    completionRate: data?.stats?.completionRate || 0,
+    intentLevel: data?.stats?.topIntentLevel || '-'
+  }
+  const trend = Array.isArray(data?.visitTrend) ? data.visitTrend : []
+  trendOption.value.xAxis.data = trend.map(t => t.date)
+  trendOption.value.series[0].data = trend.map(t => t.count)
+}
+
+onMounted(loadData)
+</script>
+
+<style scoped>
+.stats {
+  display: flex;
+  justify-content: space-around;
+  text-align: center;
+}
+.stat-item {
+  flex: 1;
+}
+.value {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.chart {
+  width: 100%;
+  height: 260px;
+}
+</style>

--- a/frontend/src/views/mobile/LoginMobile.vue
+++ b/frontend/src/views/mobile/LoginMobile.vue
@@ -38,7 +38,7 @@ const submit = async () => {
       await userStore.userLogin(form)
       // 根据当前路径决定跳转到移动端还是 PC 仪表盘
       if (route.path.startsWith('/m')) {
-        router.push('/m/dashboard')
+        router.push('/m/home')
       } else {
         router.push('/dashboard')
       }

--- a/frontend/src/views/mobile/VisitDetailMobile.vue
+++ b/frontend/src/views/mobile/VisitDetailMobile.vue
@@ -4,8 +4,8 @@
       <el-descriptions :column="1" border>
         <el-descriptions-item label="客户">{{ data.customerName }}</el-descriptions-item>
         <el-descriptions-item label="日期">{{ data.visitDate }}</el-descriptions-item>
-        <el-descriptions-item label="类型">{{ data.visitType }}</el-descriptions-item>
-        <el-descriptions-item label="状态">{{ data.status }}</el-descriptions-item>
+        <el-descriptions-item label="类型">{{ typeMap[data.visitType] || data.visitType }}</el-descriptions-item>
+        <el-descriptions-item label="状态">{{ statusMap[data.status] || data.status }}</el-descriptions-item>
       </el-descriptions>
       <div class="content" v-if="data.content">
         <h4>交流内容</h4>
@@ -23,6 +23,14 @@ import { getVisitDetail } from '@/api/visits'
 
 const route = useRoute()
 const data = ref(null)
+
+const typeMap = { PHONE: '电话', VISIT: '上门拜访' }
+const statusMap = {
+  PLANNED: '已安排',
+  IN_PROGRESS: '进行中',
+  COMPLETED: '已完成',
+  CANCELLED: '已取消'
+}
 
 onMounted(async () => {
   const { data: res } = await getVisitDetail(route.params.id)

--- a/frontend/src/views/mobile/VisitFormMobile.vue
+++ b/frontend/src/views/mobile/VisitFormMobile.vue
@@ -10,8 +10,17 @@
       <el-form-item label="类型" prop="visitType">
         <el-select v-model="form.visitType" style="width:100%">
           <el-option label="电话" value="PHONE" />
-          <el-option label="上门" value="VISIT" />
+          <el-option label="上门拜访" value="VISIT" />
         </el-select>
+      </el-form-item>
+      <el-form-item label="评分" prop="rating">
+        <el-rate v-model="form.rating" />
+      </el-form-item>
+      <el-form-item label="内容" prop="content">
+        <el-input type="textarea" v-model="form.content" rows="3" />
+      </el-form-item>
+      <el-form-item label="反馈" prop="feedback">
+        <el-input type="textarea" v-model="form.feedback" rows="3" />
       </el-form-item>
       <el-form-item>
         <el-button type="primary" style="width:100%" @click="submit">保存</el-button>
@@ -29,7 +38,14 @@ import { useRoute, useRouter } from 'vue-router'
 const router = useRouter()
 const route = useRoute()
 const formRef = ref()
-const form = reactive({ customerId: '', visitDate: '', visitType: 'PHONE' })
+const form = reactive({
+  customerId: '',
+  visitDate: '',
+  visitType: 'PHONE',
+  rating: 0,
+  content: '',
+  feedback: ''
+})
 
 if (route.params.id) {
   getVisitDetail(route.params.id).then(({ data }) => Object.assign(form, data))

--- a/frontend/src/views/mobile/VisitListMobile.vue
+++ b/frontend/src/views/mobile/VisitListMobile.vue
@@ -1,11 +1,14 @@
 <template>
   <MobileLayout title="拜访记录">
+    <template #header-right>
+      <el-button text @click="add"><el-icon><Plus /></el-icon></el-button>
+    </template>
     <el-card v-for="item in list" :key="item.id" class="mb-2" @click="view(item)">
       <div class="title-row">
         <span>{{ item.customerName }}</span>
-        <el-tag :type="item.status === 'COMPLETED' ? 'success' : 'info'" size="small">{{ item.status }}</el-tag>
+        <el-tag :type="item.status === 'COMPLETED' ? 'success' : 'info'" size="small">{{ statusMap[item.status] || item.status }}</el-tag>
       </div>
-      <div class="info">{{ item.visitDate }} | {{ item.visitType }}</div>
+      <div class="info">{{ item.visitDate }} | {{ typeMap[item.visitType] || item.visitType }}</div>
     </el-card>
   </MobileLayout>
 </template>
@@ -15,6 +18,7 @@ import { ref, onMounted } from 'vue'
 import MobileLayout from '@/layout/MobileLayout.vue'
 import { getVisitList } from '@/api/visits'
 import { useRouter } from 'vue-router'
+import { Plus } from '@element-plus/icons-vue'
 
 const router = useRouter()
 const list = ref([])
@@ -26,6 +30,22 @@ const load = async () => {
 
 const view = (item) => {
   router.push(`/m/visits/detail/${item.id}`)
+}
+
+const add = () => {
+  router.push('/m/visits/create')
+}
+
+const typeMap = {
+  PHONE: '电话',
+  VISIT: '上门拜访'
+}
+
+const statusMap = {
+  PLANNED: '已安排',
+  IN_PROGRESS: '进行中',
+  COMPLETED: '已完成',
+  CANCELLED: '已取消'
 }
 
 onMounted(load)


### PR DESCRIPTION
## Summary
- enhance mobile layout navigation and styles
- update login redirect logic
- extend mobile customer form
- add quick add buttons for mobile lists
- localize visit list/detail fields
- expand mobile visit form
- add mobile data analysis page
- route `/m/home` and `/m/analysis`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7d571c0c832c937891e6ba2f3ed2