### PR TITLE
Add mobile editing and dashboard features

### DIFF
--- a/frontend/src/views/mobile/CustomerDetailMobile.vue
+++ b/frontend/src/views/mobile/CustomerDetailMobile.vue
@@ -1,5 +1,9 @@
 <template>
   <MobileLayout title="客户详情">
+    <template #header-right>
+      <el-button text @click="edit"><el-icon><Edit /></el-icon></el-button>
+      <el-button text @click="remove"><el-icon><Delete /></el-icon></el-button>
+    </template>
     <el-card v-if="data">
       <el-descriptions :column="1" border>
         <el-descriptions-item label="姓名">{{ data.name }}</el-descriptions-item>
@@ -14,17 +18,35 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import MobileLayout from '@/layout/MobileLayout.vue'
-import { getCustomerDetail } from '@/api/customers'
+import { getCustomerDetail, deleteCustomer } from '@/api/customers'
+import { ElMessageBox, ElMessage } from 'element-plus'
+import { Edit, Delete } from '@element-plus/icons-vue'
 
 const route = useRoute()
+const router = useRouter()
 const data = ref(null)
 
 onMounted(async () => {
   const { data: res } = await getCustomerDetail(route.params.id)
   data.value = res
 })
+
+const edit = () => {
+  router.push(`/m/customers/edit/${route.params.id}`)
+}
+
+const remove = async () => {
+  try {
+    await ElMessageBox.confirm('确定删除该客户吗？', '提示', { type: 'warning' })
+    await deleteCustomer(route.params.id)
+    ElMessage.success('删除成功')
+    router.push('/m/customers/list')
+  } catch (e) {
+    if (e !== 'cancel') ElMessage.error('删除失败')
+  }
+}
 </script>
 
 <style scoped>

--- a/frontend/src/views/mobile/CustomerFormMobile.vue
+++ b/frontend/src/views/mobile/CustomerFormMobile.vue
@@ -68,7 +68,7 @@ const submit = async () => {
   } else {
     await createCustomer(form)
   }
-  router.back()
+  router.push('/m/customers/list')
 }
 </script>
 

--- a/frontend/src/views/mobile/DashboardMobile.vue
+++ b/frontend/src/views/mobile/DashboardMobile.vue
@@ -1,14 +1,131 @@
 <template>
   <MobileLayout title="首页" :showBack="false">
-    <el-card>
-      <p>移动端仪表盘内容</p>
+    <el-card v-for="item in statsCards" :key="item.title" class="stat-card">
+      <div class="stat-row">
+        <el-icon :size="20" :style="{ color: item.color }">
+          <component :is="item.icon" />
+        </el-icon>
+        <div class="info">
+          <div class="value">{{ item.value }}</div>
+          <div class="label">{{ item.title }}</div>
+        </div>
+      </div>
+    </el-card>
+
+    <el-card style="margin-top:12px">
+      <v-chart class="chart" :option="visitTrendOption" />
+    </el-card>
+
+    <el-card style="margin-top:12px">
+      <v-chart class="chart" :option="intentDistributionOption" />
+    </el-card>
+
+    <el-card style="margin-top:12px">
+      <template #header>
+        <span>待办提醒</span>
+      </template>
+      <el-timeline v-if="reminders.length">
+        <el-timeline-item
+          v-for="item in reminders"
+          :key="item.id"
+          :timestamp="item.reminderDate"
+        >
+          {{ item.title }}
+        </el-timeline-item>
+      </el-timeline>
+      <el-empty v-else description="暂无提醒" />
     </el-card>
   </MobileLayout>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
 import MobileLayout from '@/layout/MobileLayout.vue'
+import { getDashboardData } from '@/api/dashboard'
+import { use } from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { LineChart, PieChart } from 'echarts/charts'
+import {
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent
+} from 'echarts/components'
+import VChart from 'vue-echarts'
+
+use([
+  CanvasRenderer,
+  LineChart,
+  PieChart,
+  TitleComponent,
+  TooltipComponent,
+  LegendComponent,
+  GridComponent
+])
+
+const statsCards = ref([
+  { title: '总拜访次数', value: 0, icon: 'User', color: '#409EFF' },
+  { title: '已完成', value: 0, icon: 'CircleCheck', color: '#67C23A' },
+  { title: '已安排', value: 0, icon: 'Clock', color: '#E6A23C' },
+  { title: 'A类客户', value: 0, icon: 'Star', color: '#F56C6C' }
+])
+
+const visitTrendOption = ref({
+  tooltip: { trigger: 'axis' },
+  xAxis: { type: 'category', data: [] },
+  yAxis: { type: 'value' },
+  series: [{ name: '拜访次数', type: 'line', data: [], smooth: true }]
+})
+
+const intentDistributionOption = ref({
+  tooltip: { trigger: 'item' },
+  legend: { orient: 'vertical', left: 'left' },
+  series: [{ name: '意向分布', type: 'pie', radius: '50%', data: [] }]
+})
+
+const reminders = ref([])
+
+const loadData = async () => {
+  const { data } = await getDashboardData()
+  const stats = data.stats || data.basicStats || {}
+  const trend = data.visitTrend || data.trendData?.visitTrend || []
+  const intent = data.intentDistribution || data.intentStats || []
+  reminders.value = data.reminderList || data.reminders || []
+
+  statsCards.value[0].value = stats.totalVisits || 0
+  statsCards.value[1].value = stats.completedVisits || 0
+  statsCards.value[2].value = stats.scheduledVisits || 0
+  statsCards.value[3].value = stats.aLevelCustomers || 0
+
+  visitTrendOption.value.xAxis.data = trend.map(t => t.date)
+  visitTrendOption.value.series[0].data = trend.map(t => t.count)
+
+  intentDistributionOption.value.series[0].data = intent.map(i => ({
+    name: `${i.level}类客户`,
+    value: i.count
+  }))
+}
+
+onMounted(loadData)
 </script>
 
 <style scoped>
+.stat-card {
+  margin-bottom: 12px;
+}
+.stat-row {
+  display: flex;
+  align-items: center;
+}
+.info {
+  margin-left: 8px;
+}
+.value {
+  font-size: 20px;
+  font-weight: bold;
+}
+.chart {
+  width: 100%;
+  height: 260px;
+}
 </style>

--- a/frontend/src/views/mobile/VisitDetailMobile.vue
+++ b/frontend/src/views/mobile/VisitDetailMobile.vue
@@ -1,5 +1,9 @@
 <template>
   <MobileLayout title="拜访详情">
+    <template #header-right>
+      <el-button text @click="edit"><el-icon><Edit /></el-icon></el-button>
+      <el-button text @click="remove"><el-icon><Delete /></el-icon></el-button>
+    </template>
     <el-card v-if="data">
       <el-descriptions :column="1" border>
         <el-descriptions-item label="客户">{{ data.customerName }}</el-descriptions-item>
@@ -17,11 +21,14 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import MobileLayout from '@/layout/MobileLayout.vue'
-import { getVisitDetail } from '@/api/visits'
+import { getVisitDetail, deleteVisit } from '@/api/visits'
+import { ElMessageBox, ElMessage } from 'element-plus'
+import { Edit, Delete } from '@element-plus/icons-vue'
 
 const route = useRoute()
+const router = useRouter()
 const data = ref(null)
 
 const typeMap = { PHONE: '电话', VISIT: '上门拜访' }
@@ -36,6 +43,21 @@ onMounted(async () => {
   const { data: res } = await getVisitDetail(route.params.id)
   data.value = res
 })
+
+const edit = () => {
+  router.push(`/m/visits/edit/${route.params.id}`)
+}
+
+const remove = async () => {
+  try {
+    await ElMessageBox.confirm('确定删除该拜访记录吗？', '提示', { type: 'warning' })
+    await deleteVisit(route.params.id)
+    ElMessage.success('删除成功')
+    router.push('/m/visits/list')
+  } catch (e) {
+    if (e !== 'cancel') ElMessage.error('删除失败')
+  }
+}
 </script>
 
 <style scoped>

--- a/frontend/src/views/mobile/VisitFormMobile.vue
+++ b/frontend/src/views/mobile/VisitFormMobile.vue
@@ -60,7 +60,7 @@ const submit = async () => {
   } else {
     await createVisit(form)
   }
-  router.back()
+  router.push('/m/visits/list')
 }
 </script>
 


### PR DESCRIPTION
## Summary
- enrich mobile dashboard with stats, charts and reminders
- allow editing and deleting customers and visits on mobile
- refresh to list pages after submitting mobile forms

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f80311228832cb09f4391b9c49154